### PR TITLE
Improve Redis view tracking fallbacks

### DIFF
--- a/src/utils/redisClient.ts
+++ b/src/utils/redisClient.ts
@@ -1,6 +1,7 @@
 const redisUrl = process.env.REDIS_URL ?? "redis://127.0.0.1:6379";
 const upstashUrl = process.env.UPSTASH_REDIS_REST_URL;
 const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+const hasUpstash = Boolean(upstashUrl && upstashToken);
 
 let redisClient: any | null = null;
 let redisUnavailable = false;
@@ -45,9 +46,18 @@ async function readCounter(client: any, key: string): Promise<number> {
 
 export async function incrementArticleView(slug: string): Promise<number> {
         const key = `article:${slug}:views`;
+
+        if (hasUpstash) {
+                const upstashResult = await incrementWithUpstash(key);
+                if (typeof upstashResult === "number") {
+                        return upstashResult;
+                }
+        }
+
         const client = createRedisClient();
         if (!client) {
-                return incrementWithUpstash(key);
+                console.warn("No Redis backend available to increment view count");
+                return 0;
         }
 
         try {
@@ -55,61 +65,85 @@ export async function incrementArticleView(slug: string): Promise<number> {
                 return await readCounter(client, key);
         } catch (error) {
                 console.error("Failed to increment article view count", error);
-                return incrementWithUpstash(key);
+                return typeof upstashUrl === "string" ? (await incrementWithUpstash(key)) ?? 0 : 0;
         }
 }
 
 export async function getArticleViewCount(slug: string): Promise<number> {
         const key = `article:${slug}:views`;
+
+        if (hasUpstash) {
+                const upstashValue = await fetchUpstashValue(key);
+                if (typeof upstashValue === "number") {
+                        return upstashValue;
+                }
+        }
+
         const client = createRedisClient();
         if (!client) {
-                return fetchUpstashValue(key);
+                console.warn("No Redis backend available to fetch view count");
+                return 0;
         }
 
         try {
                 return await readCounter(client, key);
         } catch (error) {
                 console.error("Failed to fetch article view count", error);
-                return fetchUpstashValue(key);
+                return typeof upstashUrl === "string" ? (await fetchUpstashValue(key)) ?? 0 : 0;
         }
 }
 
-async function incrementWithUpstash(key: string): Promise<number> {
+async function incrementWithUpstash(key: string): Promise<number | null> {
         if (!upstashUrl || !upstashToken) {
-                return 0;
+                return null;
         }
 
         try {
-                const response = await fetch(`${upstashUrl}/incr/${key}`, {
+                const response = await fetch(`${upstashUrl}/incr/${encodeURIComponent(key)}`, {
+                        method: "POST",
+                        cache: "no-store",
                         headers: {
                                 Authorization: `Bearer ${upstashToken}`,
                         },
                 });
+
+                if (!response.ok) {
+                        console.error(`Upstash increment failed with status ${response.status}`);
+                        return null;
+                }
+
                 const data = (await response.json()) as { result?: number | string };
                 const parsed = Number(data.result ?? 0);
-                return Number.isNaN(parsed) ? 0 : parsed;
+                return Number.isNaN(parsed) ? null : parsed;
         } catch (error) {
                 console.error("Failed to increment article view count via Upstash", error);
-                return 0;
+                return null;
         }
 }
 
-async function fetchUpstashValue(key: string): Promise<number> {
+async function fetchUpstashValue(key: string): Promise<number | null> {
         if (!upstashUrl || !upstashToken) {
-                return 0;
+                return null;
         }
 
         try {
-                const response = await fetch(`${upstashUrl}/get/${key}`, {
+                const response = await fetch(`${upstashUrl}/get/${encodeURIComponent(key)}`, {
+                        cache: "no-store",
                         headers: {
                                 Authorization: `Bearer ${upstashToken}`,
                         },
                 });
+
+                if (!response.ok) {
+                        console.error(`Upstash fetch failed with status ${response.status}`);
+                        return null;
+                }
+
                 const data = (await response.json()) as { result?: number | string | null };
                 const parsed = Number(data.result ?? 0);
-                return Number.isNaN(parsed) ? 0 : parsed;
+                return Number.isNaN(parsed) ? null : parsed;
         } catch (error) {
                 console.error("Failed to fetch article view count via Upstash", error);
-                return 0;
+                return null;
         }
 }


### PR DESCRIPTION
## Summary
- ensure Upstash REST endpoints are used when available for article view tracking
- add clearer handling when no Redis backend is configured and keep counts from failing silently
- avoid cached Upstash responses by encoding keys and using explicit request methods

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927b95db57c83328db72e1db6d80b79)