### PR TITLE
Use Bun Redis client for view counters

### DIFF
--- a/src/utils/redisClient.ts
+++ b/src/utils/redisClient.ts
@@ -1,25 +1,16 @@
-const redisUrl = process.env.REDIS_URL ?? "redis://127.0.0.1:6379";
-const upstashUrl = process.env.UPSTASH_REDIS_REST_URL;
-const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
-const hasUpstash = Boolean(upstashUrl && upstashToken);
+import { redis as bunRedis, type RedisClient } from "bun";
 
-let redisClient: any | null = null;
+let redisClient: RedisClient | null = null;
 let redisUnavailable = false;
 
-function createRedisClient() {
+function createRedisClient(): RedisClient | null {
         if (redisUnavailable) {
                 return null;
         }
 
         if (!redisClient) {
                 try {
-                        const redisConstructor =
-                                typeof Bun !== "undefined" && (Bun as any)?.Redis ? (Bun as any).Redis : null;
-                        if (!redisConstructor) {
-                                return null;
-                        }
-
-                        redisClient = new redisConstructor({ url: redisUrl });
+                        redisClient = bunRedis;
                 } catch (error) {
                         console.error("Failed to initialize Bun Redis client", error);
                         redisUnavailable = true;
@@ -30,8 +21,8 @@ function createRedisClient() {
         return redisClient;
 }
 
-async function readCounter(client: any, key: string): Promise<number> {
-        const value = await client.get(key);
+async function readCounter(client: RedisClient, key: string): Promise<number> {
+        const value = await client.get<number | string | null>(key);
         if (typeof value === "number") {
                 return value;
         }
@@ -47,13 +38,6 @@ async function readCounter(client: any, key: string): Promise<number> {
 export async function incrementArticleView(slug: string): Promise<number> {
         const key = `article:${slug}:views`;
 
-        if (hasUpstash) {
-                const upstashResult = await incrementWithUpstash(key);
-                if (typeof upstashResult === "number") {
-                        return upstashResult;
-                }
-        }
-
         const client = createRedisClient();
         if (!client) {
                 console.warn("No Redis backend available to increment view count");
@@ -65,19 +49,13 @@ export async function incrementArticleView(slug: string): Promise<number> {
                 return await readCounter(client, key);
         } catch (error) {
                 console.error("Failed to increment article view count", error);
-                return typeof upstashUrl === "string" ? (await incrementWithUpstash(key)) ?? 0 : 0;
+                redisUnavailable = true;
+                return 0;
         }
 }
 
 export async function getArticleViewCount(slug: string): Promise<number> {
         const key = `article:${slug}:views`;
-
-        if (hasUpstash) {
-                const upstashValue = await fetchUpstashValue(key);
-                if (typeof upstashValue === "number") {
-                        return upstashValue;
-                }
-        }
 
         const client = createRedisClient();
         if (!client) {
@@ -89,61 +67,7 @@ export async function getArticleViewCount(slug: string): Promise<number> {
                 return await readCounter(client, key);
         } catch (error) {
                 console.error("Failed to fetch article view count", error);
-                return typeof upstashUrl === "string" ? (await fetchUpstashValue(key)) ?? 0 : 0;
-        }
-}
-
-async function incrementWithUpstash(key: string): Promise<number | null> {
-        if (!upstashUrl || !upstashToken) {
-                return null;
-        }
-
-        try {
-                const response = await fetch(`${upstashUrl}/incr/${encodeURIComponent(key)}`, {
-                        method: "POST",
-                        cache: "no-store",
-                        headers: {
-                                Authorization: `Bearer ${upstashToken}`,
-                        },
-                });
-
-                if (!response.ok) {
-                        console.error(`Upstash increment failed with status ${response.status}`);
-                        return null;
-                }
-
-                const data = (await response.json()) as { result?: number | string };
-                const parsed = Number(data.result ?? 0);
-                return Number.isNaN(parsed) ? null : parsed;
-        } catch (error) {
-                console.error("Failed to increment article view count via Upstash", error);
-                return null;
-        }
-}
-
-async function fetchUpstashValue(key: string): Promise<number | null> {
-        if (!upstashUrl || !upstashToken) {
-                return null;
-        }
-
-        try {
-                const response = await fetch(`${upstashUrl}/get/${encodeURIComponent(key)}`, {
-                        cache: "no-store",
-                        headers: {
-                                Authorization: `Bearer ${upstashToken}`,
-                        },
-                });
-
-                if (!response.ok) {
-                        console.error(`Upstash fetch failed with status ${response.status}`);
-                        return null;
-                }
-
-                const data = (await response.json()) as { result?: number | string | null };
-                const parsed = Number(data.result ?? 0);
-                return Number.isNaN(parsed) ? null : parsed;
-        } catch (error) {
-                console.error("Failed to fetch article view count via Upstash", error);
-                return null;
+                redisUnavailable = true;
+                return 0;
         }
 }


### PR DESCRIPTION
## Summary
- replace custom URL-based Redis handling with Bun's built-in redis client
- simplify view counter helpers to use the native client and remove Upstash fallback

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927bc024a8c8332b0b82717df0bd52d)