### PR TITLE
Add build script and guard Bun redis dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,39 +1,40 @@
 {
-	"name": "campinasfighters",
-	"version": "0.1.0",
-	"private": true,
-        "scripts": {
-                "dev": "bun run bun-ssr-server.ts",
-                "vercel": "next build",
-                "start": "NODE_ENV=production bun run bun-ssr-server.ts",
-                "lint": "next lint",
-		"create:mylint": "bunx --bun biome init && bun mylint",
-		"mylint": "bunx biome format --write",
-		"next:update": "bun add next@latest react@latest react-dom@latest eslint-config-next@latest",
-		"commit": "git pull && bun update && bun getSecurity.ts && bun run vercel && bun mylint && read -p 'Descriptions Commit: ' message && git add . && echo -n \"$message - \" && node getTime.js | xargs -I {} git commit -m \"$message - {}\" && git push",
-		"clean": "rm -rf node_modules && bun install"
-	},
-	"dependencies": {
-		"dayjs": "^1.11.19",
-		"eslint-config-next": "^16.0.4",
-		"feed": "^5.1.0",
-		"framer-motion": "^12.23.24",
-		"gray-matter": "^4.0.3",
-		"jspdf": "^3.0.4",
-		"jspdf-autotable": "^5.0.2",
-		"marked": "^16.4.2",
-		"next": "^16.0.4",
-		"next-seo": "^6.8.0",
-		"react": "^19.2.0",
-		"react-dom": "^19.2.0",
-		"sonner": "^2.0.7",
-		"styled-components": "^6.1.19"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.3.7",
-		"typescript": "^5.9.3",
-		"@types/node": "^20.19.25",
-		"@types/react": "^19.2.7",
-		"@types/react-dom": "^19.2.3"
-	}
+  "name": "campinasfighters",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "next build",
+    "dev": "bun run bun-ssr-server.ts",
+    "vercel": "next build",
+    "start": "NODE_ENV=production bun run bun-ssr-server.ts",
+    "lint": "next lint",
+    "create:mylint": "bunx --bun biome init && bun mylint",
+    "mylint": "bunx biome format --write",
+    "next:update": "bun add next@latest react@latest react-dom@latest eslint-config-next@latest",
+    "commit": "git pull && bun update && bun getSecurity.ts && bun run vercel && bun mylint && read -p 'Descriptions\n Commit: ' message && git add . && echo -n \"$message - \" && node getTime.js | xargs -I {} git commit -m \"$message - {}\" && git push",
+    "clean": "rm -rf node_modules && bun install"
+  },
+  "dependencies": {
+    "dayjs": "^1.11.19",
+    "eslint-config-next": "^16.0.4",
+    "feed": "^5.1.0",
+    "framer-motion": "^12.23.24",
+    "gray-matter": "^4.0.3",
+    "jspdf": "^3.0.4",
+    "jspdf-autotable": "^5.0.2",
+    "marked": "^16.4.2",
+    "next": "^16.0.4",
+    "next-seo": "^6.8.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "sonner": "^2.0.7",
+    "styled-components": "^6.1.19"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.3.7",
+    "typescript": "^5.9.3",
+    "@types/node": "^20.19.25",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3"
+  }
 }

--- a/src/types/bun.d.ts
+++ b/src/types/bun.d.ts
@@ -1,0 +1,10 @@
+declare module "bun" {
+  interface RedisClient {
+    get<T>(key: string): Promise<T | null>;
+    incr(key: string): Promise<void>;
+  }
+
+  const redis: RedisClient;
+
+  export { redis, type RedisClient };
+}


### PR DESCRIPTION
## Summary
- add a standard `build` script that runs `next build`
- provide Bun Redis type declarations and lazy module loading
- make Redis usage resilient when Bun is unavailable so builds complete

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927bd9816ec8332b43fca30f5210ab9)