### PR TITLE
Limit SnowOverlay to December

### DIFF
--- a/src/components/SnowOverlay.tsx
+++ b/src/components/SnowOverlay.tsx
@@ -13,9 +13,7 @@ const OPACITY_MIN = 0.35;
 const OPACITY_MAX = 0.9;
 
 function isHolidayWindow(d: Date): boolean {
-	const m = d.getMonth();
-	const day = d.getDate();
-	return (m === 11 && day >= 1) || (m === 0 && day <= 2);
+        return d.getMonth() === 11;
 }
 
 function prefersReducedMotion(): boolean {


### PR DESCRIPTION
## Summary
- restrict SnowOverlay activation window to December only

## Testing
- bun run lint *(fails: Invalid project directory provided, no such directory: /workspace/website-yagasaki/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1c6fece08332aa8c191e36007d50)