### PR TITLE
Allow forcing snow overlay even with reduced motion

### DIFF
--- a/src/components/SnowOverlay.tsx
+++ b/src/components/SnowOverlay.tsx
@@ -12,6 +12,8 @@ const PER_FLAKE_DRIFT = 0.6;
 const OPACITY_MIN = 0.35;
 const OPACITY_MAX = 0.9;
 
+const FORCE_SNOW = process.env.NEXT_PUBLIC_FORCE_SNOW === "true";
+
 function prefersReducedMotion(): boolean {
         if (typeof window === "undefined") return false;
         return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -58,11 +60,17 @@ export default function SnowOverlay() {
 
                 const media = window.matchMedia("(prefers-reduced-motion: reduce)");
                 const updateEnabled = () => {
-                        const shouldEnable = !media.matches && isDecember;
+                        const reducedMotion = media.matches;
+                        const shouldEnable = (FORCE_SNOW || !reducedMotion) && isDecember;
                         setEnabled(shouldEnable);
                         console.log(
-                                `[SnowOverlay] Update enabled => reducedMotion=${media.matches}, isDecember=${isDecember}, enabled=${shouldEnable}`
+                                `[SnowOverlay] Update enabled => reducedMotion=${reducedMotion}, isDecember=${isDecember}, enabled=${shouldEnable}`
                         );
+                        if (!shouldEnable && reducedMotion && isDecember && !FORCE_SNOW) {
+                                console.info(
+                                        "[SnowOverlay] Overlay disabled to respect prefers-reduced-motion. Set NEXT_PUBLIC_FORCE_SNOW=true to override this behavior."
+                                );
+                        }
                 };
 
                 updateEnabled();


### PR DESCRIPTION
## Summary
- allow the snow overlay to be forced on via the NEXT_PUBLIC_FORCE_SNOW flag even when prefers-reduced-motion is enabled
- add a console notice explaining when the overlay is disabled because of reduced motion

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f25195da4833281f50b2bba54dcab)