### PR TITLE
Add Portuguese 2026 Full Stack Roadmap article

### DIFF
--- a/articles/roadmap-fullstack-2026.md
+++ b/articles/roadmap-fullstack-2026.md
@@ -1,0 +1,112 @@
+---
+title: "Roadmap completo para dev full stack em 2026"
+excerpt: "Um guia em português para evoluir no front-end, back-end, DevOps, dados e carreira com foco em 2026."
+image: "https://images.unsplash.com/photo-1521737711867-e3b97375f902?auto=format&fit=crop&w=1200&q=80"
+tags: ["Fullstack", "Roadmap", "Carreira", "Frontend", "Backend"]
+date: "2026-01-15"
+---
+
+![](https://images.unsplash.com/photo-1521737711867-e3b97375f902?auto=format&fit=crop&w=1200&q=80 "Annie Spratt")
+
+Se você quer ser um desenvolvedor full stack em 2026, precisa pensar além de “saber React e Node”. O mercado pede visão de produto, base sólida em engenharia e capacidade de entregar do protótipo ao deploy. A seguir, você encontra um roteiro completo em português, organizado por etapas, para guiar seu estudo e suas escolhas.
+
+<!--truncate-->
+
+## 1) Fundamentos que sustentam tudo
+
+Antes de frameworks, construa a base:
+
+- **Lógica de programação e estruturas de dados**: arrays, listas, árvores, hashmaps, algoritmos de busca e ordenação.
+- **HTTP e web**: como funcionam requisições, respostas, status codes, cookies, cache e CORS.
+- **Git e versionamento**: branches, pull requests, code review e boas mensagens de commit.
+- **Linux e linha de comando**: navegação, permissões, scripts simples e automações.
+
+Essa etapa acelera todo o restante, porque você entende o “porquê” das ferramentas.
+
+## 2) Front-end moderno e acessível
+
+O front-end é o ponto de contato com o usuário. Foque em:
+
+- **HTML semântico e acessibilidade**: ARIA, navegação por teclado e contraste.
+- **CSS moderno**: Flexbox, Grid, responsividade, design system e tokens.
+- **JavaScript/TypeScript**: tipagem, async/await, módulos, consumo de APIs.
+- **Framework principal**: React, Vue ou Svelte — escolha um e aprofunde.
+- **Performance**: code splitting, lazy loading, otimização de imagens e Core Web Vitals.
+
+Em 2026, **UX, acessibilidade e performance** diferenciam profissionais comuns dos excelentes.
+
+## 3) Back-end escalável e seguro
+
+O back-end precisa ser confiável e seguro. O caminho é:
+
+- **Linguagem de servidor**: Node.js, Python, Go ou Java.
+- **APIs**: REST, GraphQL, validação, rate limiting e documentação (OpenAPI).
+- **Autenticação e autorização**: JWT, OAuth2, RBAC e SSO.
+- **Testes**: unitários, integração e contract tests.
+- **Boas práticas**: logs estruturados, tratamento de erros e observabilidade.
+
+Aqui, **segurança** e **manutenção** são tão importantes quanto entregar rápido.
+
+## 4) Bancos de dados e cache
+
+Dados são o coração do produto:
+
+- **SQL**: modelagem, índices, joins, migrations e transações.
+- **NoSQL**: casos de uso para documentos, chave-valor e timeseries.
+- **Cache**: Redis, estratégias de invalidação e TTL.
+- **Mensageria**: filas e streams para sistemas desacoplados.
+
+Saber desenhar o modelo certo evita gargalos e reduz custo.
+
+## 5) DevOps para não depender de ninguém
+
+Full stack de verdade entende o caminho até produção:
+
+- **Containers**: Docker, imagens, volumes e boas práticas.
+- **CI/CD**: pipelines, testes automatizados e deploys seguros.
+- **Cloud**: AWS, GCP ou Azure com serviços essenciais.
+- **Monitoramento**: métricas, logs e alertas.
+- **Infra como código**: Terraform ou similares.
+
+Não precisa ser especialista em tudo, mas deve **saber operar**.
+
+## 6) Produto, negócio e colaboração
+
+Habilidade técnica sem visão de produto limita seu impacto:
+
+- **Discovery e UX**: entender o problema antes de programar.
+- **Comunicação**: escrever documentação clara e apresentar decisões.
+- **Trabalho em equipe**: feedback, code review e empatia.
+- **Métricas**: acompanhar resultados e experimentar melhorias.
+
+Em 2026, a diferença entre “programador” e “engenheiro” é a forma como você resolve problemas reais.
+
+## 7) IA aplicada ao dia a dia
+
+Conhecer IA é diferencial, mesmo sem ser especialista:
+
+- **Prompting e automação**: acelerar tarefas repetitivas.
+- **Integrações com APIs de IA**: análise de texto, resumo, classificação.
+- **Ética e segurança**: privacidade, viés e limites de uso.
+
+O objetivo não é substituir seu trabalho, mas **aumentar sua produtividade**.
+
+## 8) Portfólio e carreira
+
+Seu currículo mais forte é o que você entrega:
+
+- **Projetos públicos**: apps completos com README e demo.
+- **Casos reais**: explicando decisões técnicas e resultados.
+- **Networking**: comunidades, eventos e colaboração.
+- **Atualização constante**: aprender a aprender é obrigatório.
+
+Invista em **qualidade**, não em quantidade.
+
+## Como usar este roadmap na prática
+
+1. Escolha um stack principal (por exemplo, React + Node + PostgreSQL).
+2. Monte um projeto completo e evolua em ciclos.
+3. A cada ciclo, melhore um tópico (performance, segurança, testes, deploy).
+4. Documente tudo e publique.
+
+Se você seguir esse caminho com consistência, em 2026 terá um perfil full stack moderno, confiável e altamente competitivo.


### PR DESCRIPTION
### Motivation
- Provide a comprehensive Portuguese roadmap for full stack developers targeting 2026, covering front-end, back-end, DevOps, dados, IA and career topics.
- Make the site content more accessible to Portuguese-speaking readers with actionable study guidance and practical steps.
- Consolidate best-practice topics (fundamentals, performance, security, CI/CD) into a single beginner-to-advanced guide.
- Help readers build a practical portfolio and development workflow with a step-by-step usage section.

### Description
- Added `articles/roadmap-fullstack-2026.md`, a new Markdown article with frontmatter (`title`, `excerpt`, `image`, `tags`, `date`).
- The article contains structured sections for fundamentals, front-end, back-end, bancos de dados/cache, DevOps, produto/colaboração, IA aplicada e portfólio.
- Content is written in Portuguese and includes `<!--truncate-->` for the site's excerpt handling and an illustrative header image.
- No code or configuration changes were made outside the new content file.

### Testing
- No automated tests were executed for this content-only change.
- CI/site build was not run as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e6d22320c8332844dcf032b103b35)