### PR TITLE
Adicionar destaque de sintaxe para blocos de código em artigos

### DIFF
--- a/src/components/ArticleDetails.ts
+++ b/src/components/ArticleDetails.ts
@@ -452,10 +452,21 @@ const ArticleDetails = styled.div`
         }
 
         pre {
-            margin: 0;
+            margin: 1rem 0;
+            border-radius: 8px;
+            overflow: auto;
         }
 
-        code {
+        pre code {
+            display: block;
+            padding: 1rem;
+            font-family: "JetBrains Mono", monospace;
+            font-size: 14px;
+            line-height: 1.5;
+            white-space: pre;
+        }
+
+        :not(pre) > code {
             position: relative;
             background-color: var(--code);
             color: var(--pink);

--- a/src/pages/artigo/[slug].tsx
+++ b/src/pages/artigo/[slug].tsx
@@ -8,11 +8,21 @@ import calculateReadingTime from "@/utils/calculateReadingTime";
 import formatDate from "@/utils/formatDate";
 import { NextSeo } from "next-seo";
 import Head from "next/head";
+import Script from "next/script";
 import Footer from "@/components/Footer";
 import Navigation from "@/components/Navigation";
 import { Frontmatter } from "@/types/Frontmatter";
 import { PostProps } from "@/types/PostProps";
 import { incrementArticleView } from "@/utils/redisClient";
+import { useEffect } from "react";
+
+declare global {
+  interface Window {
+    hljs?: {
+      highlightAll: () => void;
+    };
+  }
+}
 
 export const getServerSideProps: GetServerSideProps<PostProps> = async ({
   params,
@@ -97,6 +107,12 @@ export default function PostPage({
 
   const formattedViews = new Intl.NumberFormat("pt-BR").format(viewCount ?? 0);
 
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.hljs?.highlightAll();
+    }
+  }, [content]);
+
   return (
     <>
       <NextSeo
@@ -136,7 +152,16 @@ export default function PostPage({
           type="image/png"
           href="https://github.com/Yagasaki7K.png"
         />
+        <link
+          rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
+        />
       </Head>
+      <Script
+        src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"
+        strategy="afterInteractive"
+        onLoad={() => window.hljs?.highlightAll()}
+      />
 
       <Navigation />
 


### PR DESCRIPTION
### Motivation
- Artigos com trechos de código não possuíam destaque de sintaxe, tornando códigos difíceis de ler.;
- A intenção é aplicar um tema de destaque e permitir que blocos de código sejam renderizados com cores do tema.;

### Description
- Carrega Highlight.js via CDN e o tema `github-dark` em `src/pages/artigo/[slug].tsx` e chama `hljs.highlightAll()` client-side usando `useEffect`.;
- Declara `Window.hljs` para TypeScript e injeta o `Script` do Next.js com `strategy="afterInteractive"` para inicializar a biblioteca.;
- Ajusta o estilo em `src/components/ArticleDetails.ts` para aplicar estilos a `pre` e `pre code` e altera o seletor de código inline para `:not(pre) > code` para evitar conflito com o tema de destaque.;
- Optei por carregar assets via CDN (em vez de instalar pacotes) após tentativas de `bun add` retornarem erro de acesso ao registry.;

### Testing
- Iniciou o servidor de desenvolvimento com `bun run dev`, que iniciou, porém logs de SSR indicaram um erro de tempo de desenvolvimento relacionado ao pacote `styled-components` ausente, gerando respostas 500 para algumas rotas.;
- Executado um script Playwright para capturar uma tela da página do artigo e gerou o artefato `artifacts/article-highlight.png` para inspeção visual.;
- Commit das alterações realizado com a mensagem `Add syntax highlighting for article code blocks` e commit bem sucedido.;
- Não foram executados testes unitários automatizados adicionais nesta alteração.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fbe11ab948332bad9732131cf0c17)