### PR TITLE
Enable static export and convert article pages to SSG

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
     /* config options here */
     reactStrictMode: true,
+    output: "export",
     compiler: {
         styledComponents: true,
     },


### PR DESCRIPTION
### Motivation
- The app previously required server-side rendering for article pages which prevented static export during builds. 
- Article view counting relied on a runtime Redis increment that is incompatible with static export. 

### Description
- Added `output:

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960e7a380148332b130aa988b749255)