### PR TITLE
style: aplicar tema Dracula e JetBrainsMono Nerd Font nos blocos de código

### DIFF
--- a/src/components/ArticleDetails.ts
+++ b/src/components/ArticleDetails.ts
@@ -455,25 +455,68 @@ const ArticleDetails = styled.div`
             margin: 1rem 0;
             border-radius: 8px;
             overflow: auto;
+            background: #282a36;
+            border: 1px solid #44475a;
         }
 
         pre code {
             display: block;
             padding: 1rem;
-            font-family: "JetBrains Mono", monospace;
+            font-family: "JetBrainsMono Nerd Font", "JetBrains Mono", monospace;
             font-size: 14px;
             line-height: 1.5;
             white-space: pre;
+            color: #f8f8f2;
+            background: #282a36;
+        }
+
+        pre code .hljs-comment,
+        pre code .hljs-quote {
+            color: #6272a4;
+        }
+
+        pre code .hljs-keyword,
+        pre code .hljs-selector-tag,
+        pre code .hljs-literal,
+        pre code .hljs-type {
+            color: #ff79c6;
+        }
+
+        pre code .hljs-title,
+        pre code .hljs-title.function_,
+        pre code .hljs-function .hljs-title,
+        pre code .hljs-variable,
+        pre code .hljs-attr,
+        pre code .hljs-property {
+            color: #50fa7b;
+        }
+
+        pre code .hljs-string,
+        pre code .hljs-subst,
+        pre code .hljs-meta .hljs-string {
+            color: #f1fa8c;
+        }
+
+        pre code .hljs-number,
+        pre code .hljs-symbol,
+        pre code .hljs-bullet {
+            color: #bd93f9;
+        }
+
+        pre code .hljs-built_in,
+        pre code .hljs-doctag {
+            color: #8be9fd;
         }
 
         :not(pre) > code {
             position: relative;
-            background-color: var(--code);
-            color: var(--pink);
+            background-color: #282a36;
+            color: #f1fa8c;
+            border: 1px solid #44475a;
             border-radius: 8px;
             margin: 1rem 0;
             padding: 0.25rem 0.5rem;
-            font-family: "JetBrains Mono", monospace;
+            font-family: "JetBrainsMono Nerd Font", "JetBrains Mono", monospace;
             font-size: 14px;
             line-height: 1.4;
             overflow: auto;

--- a/src/pages/artigo/[slug].tsx
+++ b/src/pages/artigo/[slug].tsx
@@ -156,7 +156,7 @@ export default function PostPage({
         />
         <link
           rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"
+          href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/dracula.min.css"
         />
       </Head>
       <Script

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,15 @@
 @import url("https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=DM+Mono:wght@100;200;300;400;500;600;700;800;900&display=swap");
 
+@font-face {
+    font-family: "JetBrainsMono Nerd Font";
+    src: url("https://cdn.jsdelivr.net/gh/ryanoasis/nerd-fonts@v3.2.1/patched-fonts/JetBrainsMono/Ligatures/Regular/JetBrainsMonoNerdFont-Regular.ttf")
+        format("truetype");
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+}
+
 :root {
     --background: #000;
     --white: #fff;


### PR DESCRIPTION
### Motivation
- Melhorar a aparência dos trechos de código para usar o tema Dracula e uma fonte monoespaçada que suporte glyphs Nerd Font, garantindo destaque consistente para tokens como variáveis (`nameString`).

### Description
- Adiciona `@font-face` carregando `JetBrainsMono Nerd Font` em `src/styles/globals.css` para uso nos blocos de código. 
- Troca o stylesheet do Highlight.js na página de artigo de `github-dark` para `dracula` em `src/pages/artigo/[slug].tsx` usando o link CDN. 
- Atualiza os estilos de `pre code` e `:not(pre) > code` em `src/components/ArticleDetails.ts` para usar `JetBrainsMono Nerd Font`, fundo e bordas do Dracula e mapear classes do Highlight.js (`hljs-keyword`, `hljs-string`, `hljs-variable`, etc.) para as cores do tema. 

### Testing
- Executado `npm run build` e a compilação/SSG concluíram com sucesso. 
- Levantado o modo dev com `npx next dev -p 3000` e feita validação visual por screenshot (`browser:/tmp/codex_browser_invocations/a73e5e3e9ab0aab6/artifacts/artifacts/dracula-code.png`).
- Executado `npm run lint` que falhou por erro de configuração local: `Invalid project directory provided, no such directory: /workspace/website-yagasaki/lint`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984ed871da083329d8049f4d2dab8d2)