### PR TITLE
Add /taekwondo page using About layout

### DIFF
--- a/src/pages/taekwondo.tsx
+++ b/src/pages/taekwondo.tsx
@@ -1,0 +1,301 @@
+import Footer from "@/components/Footer";
+import Navigation from "@/components/Navigation";
+import Head from "next/head";
+import Link from "next/link";
+import styled from "styled-components";
+
+const TaekwondoDetails = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    max-width: 45rem;
+    margin: 0 auto;
+
+    .title {
+        font-size: 36px;
+        font-weight: 600;
+        color: var(--white);
+        margin-bottom: 1.5rem;
+
+        @media (max-width: 1024px) {
+            font-size: 2rem;
+        }
+
+        @media (max-width: 768px) {
+            font-size: 1.8rem;
+            text-align: center;
+        }
+
+        @media (max-width: 480px) {
+            font-size: 1.5rem;
+            margin-bottom: 1.25rem;
+        }
+    }
+
+    .intro {
+        margin-bottom: 1.5rem;
+        line-height: 1.7;
+    }
+
+    .subTitle {
+        font-size: 1.25rem;
+        line-height: 1.75rem;
+        margin: 1.25rem 0 0.75rem;
+        color: var(--white);
+
+        @media (max-width: 1024px) {
+            font-size: 1.15rem;
+            line-height: 1.6rem;
+        }
+
+        @media (max-width: 768px) {
+            font-size: 1.1rem;
+            text-align: center;
+        }
+
+        @media (max-width: 480px) {
+            font-size: 1rem;
+            line-height: 1.5rem;
+        }
+    }
+
+    .story {
+        margin-bottom: 0.9rem;
+        line-height: 1.7;
+    }
+
+    .achievementGroup {
+        margin-bottom: 1.25rem;
+
+        h3 {
+            color: var(--white);
+            margin-bottom: 0.4rem;
+            font-size: 1rem;
+            line-height: 1.5;
+        }
+
+        ul {
+            margin-left: 1.25rem;
+        }
+
+        li {
+            margin-bottom: 0.35rem;
+            line-height: 1.6;
+        }
+    }
+
+    @media (max-width: 1280px) {
+        max-width: 42rem;
+    }
+
+    @media (max-width: 1024px) {
+        max-width: 38rem;
+    }
+
+    @media (max-width: 820px) {
+        max-width: 32rem;
+        padding: 0 1rem;
+    }
+
+    @media (max-width: 768px) {
+        max-width: 90%;
+    }
+
+    @media (max-width: 480px) {
+        max-width: 100%;
+        padding: 0 1rem;
+    }
+
+    @media (max-width: 390px) {
+        padding: 0 0.75rem;
+    }
+`;
+
+export default function TaekwondoPage() {
+    return (
+        <>
+            <Head>
+                <title>Taekwondo - Anderson Marlon</title>
+                <link rel="icon" type="image/png" href="/campinasfighters.png" />
+            </Head>
+            <Navigation />
+            <TaekwondoDetails>
+                <article>
+                    <h1 className="title">1st Dan (Black Belt) at Campinas Fighters</h1>
+                    <p className="intro">
+                        I am Anderson Marlon (Yagasaki), a Taekwondo athlete from Campinas Fighters Team. This page summarizes my journey in
+                        Taekwondo, my technical progression, the championships I competed in, and the goals I continue to pursue in Kyorugui and
+                        Poomsae.
+                    </p>
+
+                    <section>
+                        <h2 className="subTitle">Story</h2>
+                        <p className="story">
+                            My story started in 2014 at age 17, when I was looking for a sport. Friends suggested Boxing and Muay Thai, but when I
+                            discovered Taekwondo I did not want to practice anything else.
+                        </p>
+                        <p className="story">
+                            I started with Master Márcio Eugênio and reached 6th Kup. After that period, I trained with Teacher Anderson Neneco and
+                            reached 4th Kup.
+                        </p>
+                        <p className="story">
+                            In 2020, I joined Campinas Fighters, led by Master Sérgio Pacheco and Master Alberto Iha, with continuity and authorization
+                            from Master Márcio Eugênio.
+                        </p>
+                        <p className="story">
+                            In my early competitive years, I had important results in Copa América, Liga do Vale and Campeonato Paulista. Today, my
+                            focus remains on the current Kyorugui and Poomsae categories, evolving as an athlete while also developing as a referee
+                            and coach.
+                        </p>
+                    </section>
+
+                    <section>
+                        <h2 className="subTitle">Achievements &amp; Goals</h2>
+
+                        <div className="achievementGroup">
+                            <h3>Campeonato Paulista de Taekwondo - Third Stage</h3>
+                            <ul>
+                                <li>Second Place | Campinas Fighters | 2024</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Arnold Sports - Double Match</h3>
+                            <ul>
+                                <li>Third Place | Campinas Fighters | 2024</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Campinas Fighters</h3>
+                            <ul>
+                                <li>Certificate of Attendance for 1st Kyorugui Arbitration Seminar by Nova FETESP | 2024</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Campinas Fighters</h3>
+                            <ul>
+                                <li>Referee Certificate by Kombat Taekwondo | 2024</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Campinas Fighters</h3>
+                            <ul>
+                                <li>Coach Certificate by Paulista Taekwondo Federation (FTP) | 2024</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Campinas Fighters</h3>
+                            <ul>
+                                <li>
+                                    Black Belt (1st Dan) | 2023 -{" "}
+                                    <Link href="https://yagasaki.dev/article/taekwondo-black-belt" target="_blank">
+                                        See article
+                                    </Link>
+                                </li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>São Roque International</h3>
+                            <ul>
+                                <li>First Place | Campinas Fighters | 2023</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Copa América de Taekwondo</h3>
+                            <ul>
+                                <li>Second Place | Campinas Fighters | 2023</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Campinas Fighters</h3>
+                            <ul>
+                                <li>Red w/ Black Belt (1st Kup) | 2023</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Campeonato Paulista de Taekwondo - Third Stage</h3>
+                            <ul>
+                                <li>Second Place | Campinas Fighters | 2023</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Campeonato Paulista de Taekwondo - Second Stage</h3>
+                            <ul>
+                                <li>First Place | Campinas Fighters | 2023</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Campeonato Paulista de Taekwondo - First Stage</h3>
+                            <ul>
+                                <li>Third Place | Campinas Fighters | 2023</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Festival Liga Vale</h3>
+                            <ul>
+                                <li>First Place | Campinas Fighters | 2022</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Copa América de Taekwondo</h3>
+                            <ul>
+                                <li>First Place | Campinas Fighters | 2022</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Campinas Fighters</h3>
+                            <ul>
+                                <li>Red Belt (2nd Kup) | 2023</li>
+                                <li>Blue w/ Red Belt (3th Kup) | 2022</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Teacher Anderson Neneco</h3>
+                            <ul>
+                                <li>Blue Belt (4th Kup) | 2016</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Master Márcio Eugênio</h3>
+                            <ul>
+                                <li>Green Belt (6th Kup) | 2015</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Badboy Campinas - OTC</h3>
+                            <ul>
+                                <li>Second Place | Márcio Eugênio | 2014</li>
+                            </ul>
+                        </div>
+
+                        <div className="achievementGroup">
+                            <h3>Master Márcio Eugênio</h3>
+                            <ul>
+                                <li>Yellow Belt (8th Kup) | 2014</li>
+                                <li>White Belt (10th Kup) | 2014</li>
+                            </ul>
+                        </div>
+                    </section>
+                </article>
+            </TaekwondoDetails>
+            <Footer />
+        </>
+    );
+}


### PR DESCRIPTION
### Motivation
- Restore the historical Taekwondo content (from repository history) as a new route at `/taekwondo` while keeping the current site layout and visual base used by the `/about` page.
- Keep the factual historic content intact (no invented content), avoid reintroducing legacy CSS/class wrappers, and make the page feel and behave like `/about` in structure and responsiveness.

### Description
- Added a new page file `src/pages/taekwondo.tsx` that provides the `/taekwondo` route using `Head`, `Navigation`, a centered styled wrapper (`TaekwondoDetails`), semantic `article`/`section` markup and `Footer` to match the `/about` pattern.
- Implemented a styled-components wrapper that mirrors the responsive typography, spacing and layout conventions from `src/pages/about.tsx` while keeping the styling scoped and minimal for this page.
- Restored the requested content structure and wording: main title `1st Dan (Black Belt) at Campinas Fighters`, an intro paragraph, a `Story` section with the historical facts (started 2014 at age 17; considered Boxing/Muay Thai; trained with Master Márcio Eugênio to 6th Kup, then Anderson Neneco to 4th Kup; joined Campinas Fighters in 2020; mentions of Masters Sérgio Pacheco and Alberto Iha; authorization/continuity from Master Márcio Eugênio; early wins in Copa América, Liga do Vale and Campeonato Paulista; current Kyorugui and Poomsae focus), and an `Achievements & Goals` section preserving the ordered list from the historical source including the black belt article link (`https://yagasaki.dev/article/taekwondo-black-belt`).
- Did not modify `/about` or reintroduce removed legacy wrappers/classes; page content is organized semantically and is responsive within the existing layout style.

### Testing
- Ran `npx tsc --noEmit` and the TypeScript check completed successfully.
- Ran `npm run lint` in this environment and the lint step failed due to the environment/project lint resolution (the `next lint` invocation reports an invalid project directory), so linting was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8a6426f0083209d02191dca77fdcf)