### PR TITLE
Remove `theme` prop from WTerm to fix TypeScript build error

### DIFF
--- a/src/pages/terminal.tsx
+++ b/src/pages/terminal.tsx
@@ -547,14 +547,6 @@ const TerminalPage = () => {
                     rows={28}
                     autoResize
                     cursorBlink
-                    theme={{
-                        background: "#000000",
-                        foreground: "#f5f5f5",
-                        cursor: "#f5f5f5",
-                        selectionBackground: "#4d4d4d",
-                        black: "#000000",
-                        white: "#ffffff",
-                    }}
                     onData={handleInput}
                     onReady={focus}
                     onError={(error) => {


### PR DESCRIPTION
### Motivation
- Vercel build logs showed a TypeScript type-check failure in `src/pages/terminal.tsx` when an object was passed to the `theme` prop of `@wterm/react`, where the installed package version expects a `string` for `theme`.

### Description
- Remove the inline `theme` object from the `WTerm` component in `src/pages/terminal.tsx`, leaving other props (`cols`, `rows`, `autoResize`, `cursorBlink`, `onData`, `onReady`, `onError`) unchanged.

### Testing
- Ran `bun install` and `bun run build` in the sandbox, but both steps failed due to registry `403` responses and a missing `next` binary, so the build could not be fully validated locally; this change addresses the prior Vercel type-check failure observed in the logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e295064d708320a6079f6451a1d7b2)