### PR TITLE
Remove NextSeo from _document and replace with static meta tags

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,8 +1,6 @@
 import { ServerStyleSheet } from "styled-components";
 import Document, { type DocumentContext, type DocumentInitialProps, Head, Html, Main, NextScript } from "next/document";
 
-import { NextSeo } from "next-seo";
-
 export default class MyDocument extends Document {
     // Fast refresh with NextJS doesn't broken the CSS
     static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
@@ -34,33 +32,22 @@ export default class MyDocument extends Document {
     render() {
         return (
             <Html lang="pt-br">
-                <NextSeo
-                    title="Anderson Marlon | Software Engineer"
-                    description="Hey! I’m Anderson Marlon, a software engineer and indie hacker - i'm netrunner btw."
-                    canonical={`https://yagasaki.vercel.app/`}
-                    openGraph={{
-                        url: "https://yagasaki.vercel.app/",
-                        title: "Hey! I’m Anderson Marlon, a software engineer and indie hacker - i'm netrunner btw",
-                        description: "Hey! I’m Anderson Marlon, a software engineer and indie hacker - i'm netrunner btw",
-                        images: [
-                            {
-                                url: "/thumbnail.png",
-                                width: 460,
-                                height: 460,
-                                alt: "Anderson Marlon",
-                                type: "image/png",
-                            },
-                        ],
-                        siteName: "yagasaki7k",
-                    }}
-                    twitter={{
-                        handle: "@yagasaki7k",
-                        site: "@yagasaki7k",
-                        cardType: "summary_large_image",
-                    }}
-                />
-
                 <Head>
+                    <title>Anderson Marlon | Software Engineer</title>
+                    <meta name="description" content="Hey! I’m Anderson Marlon, a software engineer and indie hacker - i'm netrunner btw." />
+                    <link rel="canonical" href="https://yagasaki.vercel.app/" />
+                    <meta property="og:url" content="https://yagasaki.vercel.app/" />
+                    <meta property="og:title" content="Hey! I’m Anderson Marlon, a software engineer and indie hacker - i'm netrunner btw" />
+                    <meta property="og:description" content="Hey! I’m Anderson Marlon, a software engineer and indie hacker - i'm netrunner btw" />
+                    <meta property="og:image" content="/thumbnail.png" />
+                    <meta property="og:image:width" content="460" />
+                    <meta property="og:image:height" content="460" />
+                    <meta property="og:image:alt" content="Anderson Marlon" />
+                    <meta property="og:image:type" content="image/png" />
+                    <meta property="og:site_name" content="yagasaki7k" />
+                    <meta name="twitter:card" content="summary_large_image" />
+                    <meta name="twitter:site" content="@yagasaki7k" />
+                    <meta name="twitter:creator" content="@yagasaki7k" />
                     <meta
                         name="keywords"
                         content="anderson, marlon, himura, yagasaki, 7k, programador, programação, code, código aberto, github, linkedin, twitter, x, tomaz, alves, desenvolvedor, engide,


### PR DESCRIPTION
### Motivation
- Loading `next-seo` inside `_document` caused a server-side module load error (`EISDIR` while reading a `.next/dev/node_modules/next-seo*` path) during document evaluation. 
- `_document` is server-only and should avoid rendering/depending on client-oriented components that can trigger external module resolution. 
- Preserve page metadata while eliminating the failing dependency from the `_document` execution path.

### Description
- Removed the `next-seo` import and `NextSeo` component usage from `src/pages/_document.tsx` and replaced it with equivalent static `<title>`, `meta`, `link rel="canonical"`, Open Graph, and Twitter tags inside `<Head>`.
- Kept the existing `styled-components` SSR logic (`ServerStyleSheet` and `getInitialProps`) intact.
- Updated the document rendering to ensure the same SEO data (title, description, OG image and properties, and twitter card) is present without importing `next-seo` on the server.

### Testing
- Ran `npm run lint`, which failed in this environment with `Invalid project directory provided, no such directory: /workspace/website-yagasaki/lint` (environment issue, not related to this change). 
- Ran `npm run build`, which failed due to `next/font` failing to fetch Google Fonts during the Turbopack build (network/font fetch errors unrelated to the `_document` change). 
- No automated tests specific to the changed file failed due to the removal of `next-seo`; the change targets a runtime server-side module load error reported in dev.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ae0612f883209016cf29a776449d)