### PR TITLE
Fix Next.js image aspect ratio warnings for link avatars

### DIFF
--- a/src/components/HomeDetails.ts
+++ b/src/components/HomeDetails.ts
@@ -50,6 +50,7 @@ const HomeDetails = styled.div`
 
                 img {
                     width: 15px;
+                    height: auto;
                     margin-right: 5px;
                 }
             }
@@ -105,6 +106,7 @@ const HomeDetails = styled.div`
 
                 img {
                     width: 15px;
+                    height: auto;
                     margin-right: 5px;
                 }
             }


### PR DESCRIPTION
### Motivation
- Next.js shows development warnings when only one image dimension is constrained, so avatar images in the link chips needed to preserve their aspect ratio when `width` is set.

### Description
- Added `height: auto;` to `.hero .p .link img` and `.hero-saas .p .link img` in `src/components/HomeDetails.ts` to ensure avatar images keep their original aspect ratio.

### Testing
- Ran `npm run lint` which failed due to an existing project lint configuration issue (`next lint` invoked with an invalid directory), and there were no errors introduced by this CSS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08af00103c8320a96a47962b640339)