### PR TITLE
Replace gray-matter with local frontmatter parser on blog page

### DIFF
--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -1,6 +1,5 @@
 import fs from "fs";
 import path from "path";
-import matter from "gray-matter";
 import calculateReadingTime from "@/utils/calculateReadingTime";
 import { useState, useMemo } from "react";
 import Link from "next/link";
@@ -10,6 +9,42 @@ import HomeDetails from "@/components/HomeDetails";
 import formatDate from "@/utils/formatDate";
 import Navigation from "@/components/Navigation";
 import { PostProps } from "@/types/PostProps";
+
+function parseFrontmatter(markdown: string) {
+    if (!markdown.startsWith("---")) {
+        return { data: {}, content: markdown };
+    }
+
+    const end = markdown.indexOf("\n---", 3);
+    if (end === -1) {
+        return { data: {}, content: markdown };
+    }
+
+    const frontmatterBlock = markdown.slice(3, end).trim();
+    const content = markdown.slice(end + 4).trimStart();
+    const data: Record<string, any> = {};
+
+    for (const line of frontmatterBlock.split("\n")) {
+        const [rawKey, ...rawValueParts] = line.split(":");
+        if (!rawKey || rawValueParts.length === 0) continue;
+
+        const key = rawKey.trim();
+        const rawValue = rawValueParts.join(":").trim();
+
+        if (rawValue.startsWith("[") && rawValue.endsWith("]")) {
+            data[key] = rawValue
+                .slice(1, -1)
+                .split(",")
+                .map((value) => value.trim().replace(/^\"|\"$/g, "").replace(/^'|'$/g, ""))
+                .filter(Boolean);
+            continue;
+        }
+
+        data[key] = rawValue.replace(/^\"|\"$/g, "").replace(/^'|'$/g, "");
+    }
+
+    return { data, content };
+}
 
 export async function getStaticProps() {
     // Get files from the posts dir
@@ -22,7 +57,7 @@ export async function getStaticProps() {
 
         const markdownWithMeta = fs.readFileSync(path.join("articles", filename), "utf-8");
 
-        const { data: frontmatter, content: markdownContent } = matter(markdownWithMeta);
+        const { data: frontmatter, content: markdownContent } = parseFrontmatter(markdownWithMeta);
         const readingTime = calculateReadingTime(markdownContent);
 
         return {


### PR DESCRIPTION
### Motivation
- Avoid runtime failure when Next/Bun attempted to load the hashed external `gray-matter-*` module which caused an `EISDIR` error on the `/blog` page.
- Keep blog page stable in SSR/dev environments by removing the dependency on `gray-matter` runtime resolution.

### Description
- Removed the `gray-matter` import from `src/pages/blog.tsx` and added a local `parseFrontmatter(markdown: string)` helper that extracts frontmatter and content from markdown files.
- Updated `getStaticProps` to call `parseFrontmatter(markdownWithMeta)` and preserved existing behavior of computing `readingTime` and sorting posts by `frontmatter.date`.
- The parser supports simple YAML-style key/value lines and bracketed arrays for tags, and it returns `{ data, content }` matching the previous structure used by the page.

### Testing
- Ran `bunx tsc --noEmit` and it passed successfully.
- Ran `bun run build` which failed due to Next.js being unable to fetch Google Fonts (`DM Mono`, `Inter`, `Poppins`) in this environment, an issue unrelated to the frontmatter change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b14b5cbc8320863dfe869bcd2dd1)