### PR TITLE
fix: remove custom styled-components Document SSR to prevent hydration mismatch

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,40 +1,6 @@
-import Document, {
-    DocumentContext,
-    DocumentInitialProps,
-    Head,
-    Html,
-    Main,
-    NextScript,
-} from "next/document";
-import { ServerStyleSheet } from "styled-components";
+import Document, { Head, Html, Main, NextScript } from "next/document";
 
 export default class MyDocument extends Document {
-    static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
-        const sheet = new ServerStyleSheet();
-        const originalRenderPage = ctx.renderPage;
-
-        try {
-            ctx.renderPage = () =>
-                originalRenderPage({
-                    enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
-                });
-
-            const initialProps = await Document.getInitialProps(ctx);
-
-            return {
-                ...initialProps,
-                styles: (
-                    <>
-                        {initialProps.styles}
-                        {sheet.getStyleElement()}
-                    </>
-                ),
-            };
-        } finally {
-            sheet.seal();
-        }
-    }
-
     render() {
         return (
             <Html lang="pt-br">


### PR DESCRIPTION
### Motivation
- The app experienced React hydration mismatches where server-rendered class names/DOM diverged from the client, likely caused by custom `styled-components` SSR integration in the Document layer.
- Modern Next.js/Turbopack plus `compiler.styledComponents: true` provides built-in handling that can conflict with manual `ServerStyleSheet` collection and `getInitialProps` usage.

### Description
- Removed the custom `getInitialProps` and `ServerStyleSheet` usage from `src/pages/_document.tsx` and simplified the imports to `import Document, { Head, Html, Main, NextScript } from "next/document";`.
- Kept all document metadata and the `Html`/`Head`/`Main`/`NextScript` structure intact so page meta remains unchanged.
- Rely on the Next.js compiler-level `styledComponents` support (configured in `next.config.ts`) for SSR/hydration consistency.

### Testing
- Ran `bun run build`, which completed successfully and generated prerendered/SSG pages (production build passed).
- Ran `bun run lint`, which failed in this environment due to the project lint script invocation (`next lint` reporting an invalid project directory) rather than code issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1734f140588320a21c6cd1d3ac8f22)