### PR TITLE
Enable styled-components SSR in custom Document to fix hydration mismatch

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,6 +1,39 @@
-import Document, { Head, Html, Main, NextScript } from "next/document";
+import Document, {
+    DocumentContext,
+    Head,
+    Html,
+    Main,
+    NextScript,
+} from "next/document";
+import { ServerStyleSheet } from "styled-components";
 
 export default class MyDocument extends Document {
+    static async getInitialProps(ctx: DocumentContext) {
+        const sheet = new ServerStyleSheet();
+        const originalRenderPage = ctx.renderPage;
+
+        try {
+            ctx.renderPage = () =>
+                originalRenderPage({
+                    enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
+                });
+
+            const initialProps = await Document.getInitialProps(ctx);
+
+            return {
+                ...initialProps,
+                styles: (
+                    <>
+                        {initialProps.styles}
+                        {sheet.getStyleElement()}
+                    </>
+                ),
+            };
+        } finally {
+            sheet.seal();
+        }
+    }
+
     render() {
         return (
             <Html lang="pt-br">


### PR DESCRIPTION
### Motivation
- Fix a React hydration mismatch where server-rendered styled-components class names differed from the client output (observed in `HomeDetails`).
- Ensure server-side styles are collected and injected so class name hashing/order matches between SSR and client hydration.

### Description
- Added `ServerStyleSheet` and a `static async getInitialProps(ctx: DocumentContext)` implementation in `src/pages/_document.tsx` to collect styled-components styles during SSR.
- Injected `sheet.getStyleElement()` into the returned `styles` so server-rendered CSS is included in the initial HTML.
- Preserved existing SEO/social meta tags and the document structure and sealed the sheet in a `finally` block to avoid leaks.

### Testing
- Ran a production build with `bun run build` (Next.js `next build`) and the build completed successfully with pages pre-generated.
- Ran `bun run lint` which failed due to the local `next lint` configuration complaining about an invalid project directory (this is unrelated to the SSR fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17368c45fc83208787e5c838cb0192)